### PR TITLE
Sweep: remove all the @command decorators from cli.py

### DIFF
--- a/sweepai/cli.py
+++ b/sweepai/cli.py
@@ -127,11 +127,9 @@ def get_event_type(event: Event | IssueEvent):
     else:
         return pascal_to_snake(event.type)[: -len("_event")]
 
-@app.command()
 def test():
     cprint("Sweep AI is installed correctly and ready to go!", style="yellow")
 
-@app.command()
 def watch(
     repo_name: str,
     debug: bool = False,
@@ -242,9 +240,8 @@ def watch(
         main()
 
 
-@app.command()
 def init(override: bool = False):
-    # TODO: Fix telemetry
+    # TODO: Fix telemetry 
     if not override:
         if os.path.exists(config_path):
             with open(config_path, "r") as f:
@@ -321,7 +318,6 @@ def init(override: bool = False):
     )
 
 
-@app.command()
 def run(issue_url: str):
     if not os.path.exists(config_path):
         cprint(


### PR DESCRIPTION
# Description
This pull request removes all the `@app.command()` decorators from various functions in the `cli.py` file of the Sweep AI project. This change is likely part of a refactoring effort to modify how commands are registered and handled in the application.

# Summary
- Removed `@app.command()` decorators from the following functions in `cli.py`:
  - `test()`
  - `watch(repo_name: str, debug: bool = False)`
  - `init(override: bool = False)`
  - `run(issue_url: str)`
- Minor adjustment in the comment within the `init` function to maintain consistent spacing.

Fixes #7.

---

<details>
<summary><b>🎉 Latest improvements to Sweep:</b></summary>
<ul>
<li>New <a href="https://progress.sweep.dev">dashboard</a> launched for real-time tracking of Sweep issues, covering all stages from search to coding.</li>
<li>Integration of OpenAI's latest Assistant API for more efficient and reliable code planning and editing, improving speed by 3x.</li>
<li>Use the <a href="https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github">GitHub issues extension</a> for creating Sweep issues directly from your editor.</li>
</ul>
</details>


---

### 💡 To get Sweep to edit this pull request, you can:
* Comment below, and Sweep can edit the entire PR
* Comment on a file, Sweep will only modify the commented file
* Edit the original issue to get Sweep to recreate the PR from scratch

*This is an automated message generated by [Sweep AI](https://sweep.dev).*